### PR TITLE
refactor: Minor types cleanup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "tabWidth": 2,
   "useTabs": false,
-  "printWidth": 100
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "es5"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, FC, useContext } from 'react';
+import type { FC } from 'react';
+import { createContext, useContext } from 'react';
 import { removeNonUnit } from './utils/removeNonUnit';
 import { removeStorePrefix } from './utils/removeStorePrefix';
 
@@ -8,8 +9,7 @@ import { removeStorePrefix } from './utils/removeStorePrefix';
  * @returns Factory with `createModel` method, `useModel` hook and model `Provider`
  */
 export const modelFactory = <T extends (...args: any[]) => any>(creator: T) => {
-  // @ts-expect-error
-  const ModelContext = createContext<ReturnType<typeof creator>>(null);
+  const ModelContext = createContext<ReturnType<typeof creator> | null>(null);
   const useModel = () => {
     const model = useContext(ModelContext);
     if (!model) {

--- a/src/solid.tsx
+++ b/src/solid.tsx
@@ -1,5 +1,6 @@
 /* @jsxImportSource solid-js */
-import { useContext, createContext, Component } from 'solid-js';
+import type { Component } from 'solid-js';
+import { createContext, useContext } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import { removeNonUnit } from './utils/removeNonUnit';
 import { removeStorePrefix } from './utils/removeStorePrefix';
@@ -10,8 +11,7 @@ import { removeStorePrefix } from './utils/removeStorePrefix';
  * @returns Factory with `createModel` method, `useModel` hook and model `Provider`
  */
 export const modelFactory = <T extends (...args: any[]) => any>(creator: T) => {
-  // @ts-expect-error
-  const ModelContext = createContext<ReturnType<typeof creator>>(null);
+  const ModelContext = createContext<ReturnType<typeof creator> | null>(null);
   const useModel = () => {
     const model = useContext(ModelContext);
     if (!model) {

--- a/src/utils/removeNonUnit.ts
+++ b/src/utils/removeNonUnit.ts
@@ -3,7 +3,7 @@ import type { Unit } from 'effector';
 
 type Shape = { [key: string]: unknown };
 
-type OnlyUnits<T> = Pick<
+export type OnlyUnits<T> = Pick<
   T,
   { [Key in keyof T]-?: T[Key] extends Unit<unknown> ? Key : never }[keyof T]
 >;

--- a/src/utils/removeStorePrefix.ts
+++ b/src/utils/removeStorePrefix.ts
@@ -8,7 +8,7 @@ type UnprefixedKey<Original> = Original extends `$${infer Unprefixed}`
 
 type PrefixedKey<Key extends string> = `$${Key}`;
 
-type Unprefixed<T extends Shape> = {
+export type Unprefixed<T extends Shape> = {
   [key in UnprefixedKey<keyof T>]: T extends { [inner in key]: unknown }
     ? T[key]
     : key extends string


### PR DESCRIPTION
Please review the following code improvements:

- Remove unnecessary '@ts-expect-error' statements from context type definitions
- Export utility types to simplify package type declarations
- Utilize 'import type' syntax to eliminate build warnings

Additionally, updated the Prettier configuration to match the existing code style